### PR TITLE
chore: support 'load data LOCAL infile ...' by default

### DIFF
--- a/mo.yml
+++ b/mo.yml
@@ -13,6 +13,7 @@ jdbc:
     useServerPrepStmts: "true"
     alwaysSendSetIsolation: "false"
     useLocalSessionState: "true"
+    allowLoadLocalInfile: "true"
     zeroDateTimeBehavior: "CONVERT_TO_NULL"
     failoverReadOnly: "false"
     initialTimeout: 60


### PR DESCRIPTION
Aim:
- support exec cmd `load data LOCAL infile ...`

changes:
1. add default param `allowLoadLocalInfile: "true"` while connect mo.