### PR TITLE
implement the expect timewait

### DIFF
--- a/mo.yml
+++ b/mo.yml
@@ -6,7 +6,7 @@ jdbc:
   #- addr: "127.0.0.1:3306"
   #- addr: "127.0.0.1:3306"
   database:
-    default: ""
+    default: "test"
   paremeter:
     characterSetResults: "utf8"
     continueBatchOnError: "false"

--- a/src/main/java/io/mo/cases/SqlCommand.java
+++ b/src/main/java/io/mo/cases/SqlCommand.java
@@ -95,6 +95,18 @@ public class SqlCommand {
     @Getter
     @Setter
     private int sleeptime = 0;
+
+    @Getter
+    @Setter
+    private boolean waitExpect = false;
+
+    @Getter
+    @Setter
+    private int waitExpectInterval = 0;
+
+    @Getter
+    @Setter
+    private int waitExpectTimeout = 0;
     
     @Getter
     @Setter
@@ -152,6 +164,10 @@ public class SqlCommand {
         if (actResult != null) {
             this.testResult.setActResult(actResult.toString());
         }
+    }
+
+    public StmtResult getActResult() {
+        return actResult;
     }
 
     public boolean checkResult() {

--- a/src/main/java/io/mo/constant/COMMON.java
+++ b/src/main/java/io/mo/constant/COMMON.java
@@ -22,6 +22,7 @@ public class COMMON {
     public static String NEW_SESSION_END_FLAG = "-- @session";
     public static String BVT_SKIP_FILE_FLAG = "-- @skip:issue#";
     public static String FUNC_SLEEP_FLAG = "-- @sleep:";
+    public static String WAIT_EXPECT_FLAG = "-- @wait_expect";
     public static String BVT_ISSUE_START_FLAG = "-- @bvt:issue#";
     public static String BVT_ISSUE_END_FLAG = "-- @bvt:issue";
     public static String SORT_KEY_INDEX_FLAG = "-- @sortkey:";


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add wait_expect feature for polling query results until expected output

- Implement parsing of wait_expect flag with interval and timeout parameters

- Add retry logic in Executor to re-execute queries with configurable polling

- Add getter method for actResult in SqlCommand class


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ScriptParser"] -- "parseWaitExpectFlag" --> B["SqlCommand"]
  B -- "setWaitExpect/Interval/Timeout" --> C["Command Properties"]
  C -- "isWaitExpect check" --> D["Executor"]
  D -- "retry loop with polling" --> E["Query Re-execution"]
  E -- "checkResult validation" --> F["Result Matching"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SqlCommand.java</strong><dd><code>Add wait_expect properties and actResult getter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/mo/cases/SqlCommand.java

<ul><li>Added three new properties: <code>waitExpect</code>, <code>waitExpectInterval</code>, <br><code>waitExpectTimeout</code> with getters/setters<br> <li> Added public getter method <code>getActResult()</code> for accessing actual result</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/mo-tester/pull/196/files#diff-19408f939842011edc13728492fb71e054aba3c170e78a2417b51e60225c5ecb">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Executor.java</strong><dd><code>Implement wait_expect polling retry logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/mo/db/Executor.java

<ul><li>Implemented retry loop logic in <code>run()</code> method that polls query results <br>until expected output matches or timeout<br> <li> Added validation to ensure wait_expect only applies to query result <br>sets<br> <li> Added sleep logic in <code>genRS()</code> method to wait before generating results <br>when wait_expect is enabled<br> <li> Handles interval-based polling with deadline calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/mo-tester/pull/196/files#diff-51bc169d4f332ad3972e94662bab3a845cdf16164c9525ecc4d8a3a11e434d50">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ScriptParser.java</strong><dd><code>Add wait_expect flag parsing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/mo/util/ScriptParser.java

<ul><li>Added <code>parseWaitExpectFlag()</code> method to parse wait_expect flag with <br>interval and timeout parameters<br> <li> Integrated flag parsing into <code>processCommentLine()</code> method<br> <li> Includes validation for flag format, numeric values, and <br>interval/timeout constraints<br> <li> Logs warnings for invalid formats or values</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/mo-tester/pull/196/files#diff-ac0d55b29c2e3220150cc77936a0fe60ec18fecac05cde8aafced7a649d78802">+39/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>COMMON.java</strong><dd><code>Add wait_expect flag constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/mo/constant/COMMON.java

<ul><li>Added new constant <code>WAIT_EXPECT_FLAG = "-- @wait_expect"</code> for flag <br>recognition<br> <li> Fixed file ending formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/mo-tester/pull/196/files#diff-d37cc124498e384930c7c606e50271b72c3531e736128dd0bb5193672ff6504b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mo.yml</strong><dd><code>Update default database configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mo.yml

- Changed default database from empty string to "test"


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/mo-tester/pull/196/files#diff-94ff34af1f55907fb61b9655451c1b7b41ec79dc1c8894dca504c30373c22b89">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

